### PR TITLE
Add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - prealloc
+    - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+
+issues:
+  max-same-issues: 100
+
+run:
+  timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,6 @@ unit-tests: $(BUILD_DIRS)
 	        ./hack/test.sh $(SRC_PKGS)                          \
 	    "
 
-ADDTL_LINTERS   := gofmt,goimports,unparam
-
 .PHONY: lint
 lint: $(BUILD_DIRS)
 	@echo "running linter"
@@ -217,7 +215,7 @@ lint: $(BUILD_DIRS)
 	    --env GO111MODULE=on                                    \
 	    --env GOFLAGS="-mod=vendor"                             \
 	    $(BUILD_IMAGE)                                          \
-	    golangci-lint run --enable $(ADDTL_LINTERS) --timeout=10m --exclude-files="generated.*\.go$\" --exclude-dirs-use-default
+	    golangci-lint run
 
 $(BUILD_DIRS):
 	@mkdir -p $@

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "KIND\tNAME\tKEY\tSERIAL NUMBER\tCN\tAge")
+	_, _ = fmt.Fprintln(w, "KIND\tNAME\tKEY\tSERIAL NUMBER\tCN\tAge")
 
 	err = ListSecrets(kc, w)
 	if err != nil {
@@ -100,7 +100,7 @@ func main() {
 		panic(err)
 	}
 
-	w.Flush()
+	_ = w.Flush()
 }
 
 func ListSecrets(kc client.Client, w io.Writer) error {
@@ -113,7 +113,7 @@ func ListSecrets(kc client.Client, w io.Writer) error {
 		for k, v := range item.Data {
 			if crts, err := cert.ParseCertsPEM(v); err == nil {
 				for _, crt := range crts {
-					fmt.Fprintf(w, "SECRET\t%s/%s\t%s\t%v\t%s\t%s\n", item.GetNamespace(), item.GetName(), k, crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
+					_, _ = fmt.Fprintf(w, "SECRET\t%s/%s\t%s\t%v\t%s\t%s\n", item.GetNamespace(), item.GetName(), k, crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
 				}
 			}
 		}
@@ -131,14 +131,14 @@ func ListConfigMaps(kc client.Client, w io.Writer) error {
 		for k, v := range item.Data {
 			if crts, err := cert.ParseCertsPEM([]byte(v)); err == nil {
 				for _, crt := range crts {
-					fmt.Fprintf(w, "CFGMAP\t%s/%s\t%s\t%v\t%s\t%s\n", item.GetNamespace(), item.GetName(), k, crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
+					_, _ = fmt.Fprintf(w, "CFGMAP\t%s/%s\t%s\t%v\t%s\t%s\n", item.GetNamespace(), item.GetName(), k, crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
 				}
 			}
 		}
 		for k, v := range item.BinaryData {
 			if crts, err := cert.ParseCertsPEM(v); err == nil {
 				for _, crt := range crts {
-					fmt.Fprintf(w, "CFGMAP\t%s/%s\t%s\t%v\t%s\t%s\n", item.GetNamespace(), item.GetName(), k, crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
+					_, _ = fmt.Fprintf(w, "CFGMAP\t%s/%s\t%s\t%v\t%s\t%s\n", item.GetNamespace(), item.GetName(), k, crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
 				}
 			}
 		}
@@ -156,7 +156,7 @@ func ListAPIServices(kc client.Client, w io.Writer) error {
 		if len(item.Spec.CABundle) > 0 {
 			if crts, err := cert.ParseCertsPEM(item.Spec.CABundle); err == nil {
 				for _, crt := range crts {
-					fmt.Fprintf(w, "APISVC\t%s\t%s\t%v\t%s\t%s\n", item.GetName(), "spec.caBundle", crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
+					_, _ = fmt.Fprintf(w, "APISVC\t%s\t%s\t%v\t%s\t%s\n", item.GetName(), "spec.caBundle", crt.SerialNumber, crt.Subject.CommonName, ConvertToHumanReadableDateType(crt.NotAfter))
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Add a `.golangci.yml` configuration for golangci-lint v2, matching the config used across the other kubedb repositories.

The configured formatter is gofumpt, which aligns with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` and the linter enforce the same formatting.

### `.golangci.yml`
- Enable the **`bodyclose`**, **`prealloc`** and **`unparam`** linters.
- Exclude generated files, `client`, and `vendor` via **`linters.exclusions.paths`**.
- Use **`gofumpt`** + **`goimports`** formatters.

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
